### PR TITLE
Change placement of sudo in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ anything other than what's absolutely necessary to perform the release.
 To install the binary you can run this script on your machine
 
 ```
-curl --silent https://raw.githubusercontent.com/BrandwatchLtd/slipstream-cli-release/master/install.sh | sudo bash -s - -b /usr/local/bin
+sudo curl --silent https://raw.githubusercontent.com/BrandwatchLtd/slipstream-cli-release/master/install.sh | bash -s - -b /usr/local/bin
 ```
 
 Note: in order to install the binary to another location change `/usr/local/bin` to the path of your choice


### PR DESCRIPTION
Placing `sudo` after pipe command caused password prompt to be passed over in Z shell, placing it before works in `zsh` (tested 5.8) and `bash` (tested 5.2).